### PR TITLE
Fix build of verifast-rust

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -5,6 +5,7 @@ name: Deploy site
 
 on:
   push:
+  pull_request:
   schedule:
     - cron: '0 2 * * *'
 
@@ -29,6 +30,7 @@ jobs:
       with:
         path: ./public
   deploy:
+    if: startsWith(github.repository, 'rust-formal-methods/') && github.event_name != 'pull_request'
     needs: build
 
     permissions:

--- a/content/meetings/verifast-rust.md
+++ b/content/meetings/verifast-rust.md
@@ -1,6 +1,6 @@
 +++
 title = "Towards Sound `unsafe` Rust"
-date = 2024-10-28T19:00:00+01:00 (Paris/Zurich)
+date = 2024-10-28T19:00:00+01:00 # (Paris/Zurich)
 +++
 
 Rust guarantees memory safety and data race freedom through its type checker, which enforces *ownership* and *borrowing* rules. However, adhering strictly to these rules can limit expressiveness and restrict certain high-performance implementations. To address this limitation, Rust allows programmers to relax some type system checks within `unsafe` blocks. The challenge, however, is that maintaining type system invariants within these relaxed blocks becomes the programmer's responsibility.


### PR DESCRIPTION
Not familiar with Zola, so maybe variables have type and are not necessarily strings.